### PR TITLE
fix: Fixed import

### DIFF
--- a/lib/interfaces/mercurius-module-options.interface.ts
+++ b/lib/interfaces/mercurius-module-options.interface.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/graphql';
 import { ModuleMetadata, Type } from '@nestjs/common';
 import { GraphQLSchema } from 'graphql';
-import { IResolverValidationOptions } from '@nestjs/graphql/dist/interfaces/gql-module-options.interface';
+import { IResolverValidationOptions } from '@graphql-tools/utils';
 import { MercuriusSchemaOptions } from 'mercurius';
 import { BaseMercuriusModuleOptions } from './base-mercurius-module-options.interface';
 


### PR DESCRIPTION
Hello.

If the `tsconfig` option `skipLibCheck` is set to `false`, the build process fails.
Interface `IResolverValidationOptions` is not exported by the module.

`@nestjs/core`: 7.6.15
`nest-mercurius`: 0.8.1
`mercurius`: 7.6.1

Error log:
```cmd
node_modules/nestjs-mercurius/dist/interfaces/mercurius-module-options.interface.d.ts:4:10 - error TS2459: Module '"@nestjs/graphql/dist/interfaces/gql-module-options.interface"' declares 'IResolverValidationOptions' locally, but it is not exported.

4 import { IResolverValidationOptions } from '@nestjs/graphql/dist/interfaces/gql-module-options.interface';
           ~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/@nestjs/graphql/dist/interfaces/gql-module-options.interface.d.ts:1:10
    1 import { IResolverValidationOptions } from '@graphql-tools/utils';
               ~~~~~~~~~~~~~~~~~~~~~~~~~~
    'IResolverValidationOptions' is declared here.
```

I've set the import to the `@graphql-tools/utils` package, same as in the imported interface module.