### PR TITLE
fix(factory): return undefined if no validation rules are provided

### DIFF
--- a/lib/factories/graphql.factory.ts
+++ b/lib/factories/graphql.factory.ts
@@ -50,9 +50,9 @@ export class GraphQLFactory extends NestGraphQLFactory {
         skipCheck: true,
       };
     }
-    const parentOptions = ((await super.mergeOptions(
+    const parentOptions = (await super.mergeOptions(
       options as any,
-    )) as unknown) as MercuriusModuleOptions & {
+    )) as unknown as MercuriusModuleOptions & {
       plugins: any[];
       schema: GraphQLSchema;
     };
@@ -81,6 +81,9 @@ export class GraphQLFactory extends NestGraphQLFactory {
 
   mergeValidationRules(existingValidationRules?: ValidationRules) {
     const rules = this.validationRuleExplorerService.explore();
+    if (rules.length === 0 && !existingValidationRules) {
+      return;
+    }
     return (params) => [
       ...(existingValidationRules ? existingValidationRules(params) : []),
       ...rules.map((rule) => (context) => rule.validate(params, context)),


### PR DESCRIPTION
with the next release, query caching with validationRules function will be prevented (https://github.com/mercurius-js/mercurius/pull/485). Currently, a validation rule function will always be returned, even if there are now validation rules defined.

This fix returns undefined instead of an "empty" function if no validation rules are given