### PR TITLE
fix(federation-factory): implement workaround for federated schema

### DIFF
--- a/lib/utils/faderation-factory.util.ts
+++ b/lib/utils/faderation-factory.util.ts
@@ -73,7 +73,12 @@ export function transformFederatedSchema(schema: GraphQLSchema) {
     'FederationFactory',
     () => require('@apollo/federation'),
   );
-  const schemaString = printSchema(schema);
+
+  // Workaround for https://github.com/mercurius-js/mercurius/issues/273
+  const schemaString = printSchema(schema)
+    .replace('type Query {', 'type Query @extends {')
+    .replace('type Mutation {', 'type Mutation @extends {')
+    .replace('type Subscription {', 'type Subscription @extends {');
 
   schema = extendSchema(schema, parse(FEDERATION_SCHEMA), {
     assumeValidSDL: true,

--- a/tests/e2e/gateway.spec.ts
+++ b/tests/e2e/gateway.spec.ts
@@ -88,4 +88,36 @@ graphqlSuite('Should call service query', async (t) => {
     });
 });
 
+graphqlSuite('Should call another service query', async (t) => {
+  await request(t.app.getHttpServer())
+    .post('/graphql')
+    .send({
+      query: `
+        {
+          posts {
+            id
+            title
+            authorId
+          }
+        }
+      `,
+    })
+    .expect(200, {
+      data: {
+        posts: [
+          {
+            id: '1',
+            title: 'p1',
+            authorId: 1,
+          },
+          {
+            id: '2',
+            title: 'p2',
+            authorId: 1,
+          },
+        ],
+      },
+    });
+});
+
 graphqlSuite.run();

--- a/tests/federation/postService/post.resolver.ts
+++ b/tests/federation/postService/post.resolver.ts
@@ -1,4 +1,4 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { Post } from './post';
 import { User } from './user';
 
@@ -19,6 +19,11 @@ export const posts: Post[] = [
 
 @Resolver(() => Post)
 export class PostResolver {
+  @Query(() => [Post])
+  posts() {
+    return posts;
+  }
+
   @ResolveField(() => User)
   author(@Parent() post: Post) {
     return { __typename: 'User', id: post.authorId };


### PR DESCRIPTION
implements a fix for https://github.com/mercurius-js/mercurius/issues/273 

Inspired by https://github.com/sagahead-io/ecommerce-blueprint/blob/4a9be70a332151f9040f90575c5ccef9bb516024/commons/build-federated-schema/src/index.ts#L71

Would be great if you could merge this. It doesn't seem to have any side effects. Also added a test to ensure that the gateway picks up all queries.